### PR TITLE
feat: token config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,63 @@ A library & command line application for generating the signed developer tokens 
 
 ### Locating your identifiers:
 * **Key ID**: An identifier associated with your private key. It can be found on the [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/authkeys/list) page under Keys. Click on the appropriate key to view the ID. 
-* **Team ID**: Found on the [membership](https://developer.apple.com/account/#!/membership) page. 
+* **Team ID**: Found on the [account](https://developer.apple.com/account) page under Membership details.
 * **Service ID**: Found on the [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list/serviceId) page under Identifiers. Make sure "Services IDs" is selected from the dropdown. 
 
-### Use as a library:
+## CLI usage:
+Precompiled binaries are available on the [Releases](https://github.com/shawntoffel/go-appledev/releases) page. 
+```sh
+
+Usage of ./appledev:
+  token         Create an apple developer token.
+  config        Generate a config file.
+  version       Print the version of this application.
+
+Usage of ./appledev token:
+  -c string
+        Path to a json config file containing args.
+  -d duration
+        How long the token will be valid for. (default 30m0s)
+  -kid string
+        (required) The Key ID associated with your private key.
+  -pk string
+        (required) The path to a file containing your PEM encoded private key.
+  -sid string
+        (required) The Service ID from your developer account.
+  -tid string
+        (required) The Team ID from your developer account.
+```
+Generate a token:
+```sh
+./appledev token -pk AuthKey_ABCDE12345.p8 -kid keyId -sid serviceId -tid teamId
+```
+
+Duration `d` is an optional `time.Duration` string for when the token will expire from now. Paraphrasing the Go documentation, it may contain a sequence of decimal numbers, each with an optional fraction and a unit suffix, such as "30m", "1.5h" or "2h45m". Valid time units are "ms", "s", "m", "h", "d", "w", "y".
+
+### Config file
+A JSON config file may be used in place of args. The easiest way to create a config file is to provide your private key to `./appledev config`. This way, the private key will be properly formatted with newlines.
+
+```sh
+./appledev config -pk AuthKey_ABCDE12345.p8 -o appledev_config.json
+```
+appledev_config.json:
+```json
+{
+  "kid": "key ID",
+  "tid": "team ID",
+  "sid": "service ID",
+  "d": "10m",
+  "pk": "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"
+}
+```
+Generate a token using a config file:
+```sh
+./appledev token -c appledev_config.json
+```
+CLI args provided in addition to `-c` will take precedence over their value in the config file.
+
+## Library usage:
+This project may imported as a Go module for token generation on the fly.
 ```go
 
 import (
@@ -33,31 +86,6 @@ bytes, err := os.ReadFile(privateKeyFilePath)
 // Generate a signed JWT string.
 token, err := tokenProvider.SignedJWT(bytes)
 
-```
-
-### Use as a binary application:
-Precompiled binaries are available on the [Releases](https://github.com/shawntoffel/go-appledev/releases) page. 
-```sh
-
-Usage of ./appledev:
-  token         Create an apple developer token.
-  version       Print the version of this application.
-
-Usage of ./appledev token:
-  -d duration
-        How long the token will be valid for. (default 30m0s)
-  -kid string
-        (required) The Key ID associated with your private key.
-  -pk string
-        (required) The path to a file containing your PEM encoded private key.
-  -sid string
-        (required) The Service ID from your developer account.
-  -tid string
-        (required) The Team ID from your developer account.
-```
-
-```sh
-./appledev token -pk AuthKey_ABCDE12345.p8 -kid keyId -sid serviceId -tid teamId
 ```
 
 ## Troubleshooting

--- a/cmd/appledev/config.go
+++ b/cmd/appledev/config.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/shawntoffel/go-appledev"
+)
+
+const DefaultDuration string = "30m"
+
+type Config struct {
+	KeyID      string `json:"kid"`
+	TeamID     string `json:"tid"`
+	ServiceID  string `json:"sid"`
+	Duration   string `json:"d"`
+	PrivateKey string `json:"pk"`
+}
+
+func NewConfigFromFlags(flags *Flags) (*Config, error) {
+	config, err := NewConfig(flags.ConfigFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = config.applyFlags(flags)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func NewConfig(filePath string) (*Config, error) {
+	if len(filePath) < 1 {
+		return &Config{
+			Duration: DefaultDuration,
+		}, nil
+	}
+
+	bytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &Config{}
+
+	err = json.Unmarshal(bytes, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func (c *Config) applyFlags(flags *Flags) error {
+	if flags.KeyID != "" {
+		c.KeyID = flags.KeyID
+	}
+
+	if flags.ServiceID != "" {
+		c.ServiceID = flags.ServiceID
+	}
+
+	if flags.TeamID != "" {
+		c.TeamID = flags.TeamID
+	}
+
+	if flags.Duration > 0 {
+		c.Duration = flags.Duration.String()
+	}
+
+	if flags.PrivateKeyFilePath != "" {
+		bytes, err := os.ReadFile(flags.PrivateKeyFilePath)
+		if err != nil {
+			return err
+		}
+
+		c.PrivateKey = string(bytes)
+	}
+
+	return nil
+}
+
+func (c *Config) CreateToken() (string, error) {
+	d := c.Duration
+	if len(d) < 1 {
+		d = DefaultDuration
+	}
+
+	duration, err := time.ParseDuration(d)
+	if err != nil {
+		return "", err
+	}
+
+	tokenProvider := &appledev.ApiTokenProvider{
+		KeyID:     c.KeyID,
+		TeamID:    c.TeamID,
+		ServiceID: c.ServiceID,
+		Duration:  duration,
+	}
+
+	token, err := tokenProvider.SignedJWT([]byte(c.PrivateKey))
+	if err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
+func (c *Config) WriteToFile(filePath string) error {
+	f, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	content, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Write(content)
+	return err
+}

--- a/cmd/appledev/flag.go
+++ b/cmd/appledev/flag.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+)
+
+type Flags struct {
+	// Version subcommand
+	Version bool
+	// Token subcommand
+	Token bool
+	// Config subcommand
+	GenerateConfig bool
+
+	PrivateKeyFilePath string
+	KeyID              string
+	TeamID             string
+	ServiceID          string
+	Duration           time.Duration
+
+	// ConfigFilePath is the path to a JSON file from which config may be parsed.
+	ConfigFilePath string
+
+	// OutputFile is the destination file path where a config file may be written.
+	OutputFile string
+}
+
+func ParseFlags(args []string) (*Flags, error) {
+	flags := &Flags{}
+
+	subcommand := args[1]
+	switch subcommand {
+	case "token":
+		flags.Token = true
+		err := flags.parseTokenFlags(args)
+		if err != nil {
+			return nil, err
+		}
+	case "config":
+		flags.GenerateConfig = true
+		err := flags.parseConfigGenFlags(args)
+		if err != nil {
+			return nil, err
+		}
+	case "version":
+		flags.Version = true
+	}
+
+	return flags, nil
+}
+
+func (f *Flags) parseTokenFlags(args []string) error {
+	outputBuffer := bytes.NewBuffer([]byte{})
+
+	set := flag.NewFlagSet("token", flag.ContinueOnError)
+	set.SetOutput(outputBuffer)
+	set.StringVar(&f.ConfigFilePath, "c", f.ConfigFilePath, "Path to a json config file containing args.")
+	f.addCommonArgs(set)
+
+	err := set.Parse(args[2:])
+	if err != nil {
+		return fmt.Errorf(outputBuffer.String())
+	}
+
+	if len(f.PrivateKeyFilePath) < 1 && len(f.ConfigFilePath) < 1 {
+		fmt.Fprintf(set.Output(), "%s token: A Private key file path is required when a config file is not provided.\n\n", args[0])
+		fmt.Fprintf(set.Output(), "Usage of %s token:\n", args[0])
+		set.PrintDefaults()
+	}
+
+	errContent := outputBuffer.String()
+	if len(errContent) > 0 {
+		return fmt.Errorf(errContent)
+	}
+
+	return nil
+}
+
+func (f *Flags) parseConfigGenFlags(args []string) error {
+	outputBuffer := bytes.NewBuffer([]byte{})
+
+	set := flag.NewFlagSet("config", flag.ContinueOnError)
+	set.SetOutput(outputBuffer)
+	set.StringVar(&f.OutputFile, "o", f.OutputFile, "(required) The path where the config file will be written.")
+	f.addCommonArgs(set)
+
+	err := set.Parse(args[2:])
+	if err != nil {
+		return fmt.Errorf(outputBuffer.String())
+	}
+
+	errContent := outputBuffer.String()
+	if len(errContent) > 0 {
+		return fmt.Errorf(errContent)
+	}
+
+	return nil
+}
+
+func (f *Flags) addCommonArgs(flatSet *flag.FlagSet) {
+	flatSet.StringVar(&f.PrivateKeyFilePath, "pk", f.PrivateKeyFilePath, "(required) The path to a file containing your PEM encoded private key.")
+	flatSet.StringVar(&f.KeyID, "kid", f.KeyID, "The Key ID associated with your private key.")
+	flatSet.StringVar(&f.TeamID, "tid", f.TeamID, "The Team ID from your developer account.")
+	flatSet.StringVar(&f.ServiceID, "sid", f.ServiceID, "The Service ID from your developer account.")
+	flatSet.DurationVar(&f.Duration, "d", f.Duration, "How long the token will be valid for.")
+}
+
+func exitHelp() {
+	fmt.Printf("Usage of %s:\n", os.Args[0])
+	fmt.Println("  token    \tCreate an apple developer token.")
+	fmt.Println("  config    \tGenerate a config file.")
+	fmt.Println("  version    \tPrint the version of this application.")
+	os.Exit(1)
+}

--- a/cmd/appledev/main.go
+++ b/cmd/appledev/main.go
@@ -1,101 +1,61 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
-	"time"
-
-	"github.com/shawntoffel/go-appledev"
 )
+
+const app = "appledev"
 
 var version = "dev"
-
-var (
-	flagVersion = false
-	flagToken   = false
-)
-
-var (
-	flagTokenPKFile    = ""
-	flagTokenKeyID     = ""
-	flagTokenTeamID    = ""
-	flagTokenServiceID = ""
-	flagTokenDuration  = time.Minute * 30
-)
 
 func init() {
 	if len(os.Args) < 2 {
 		exitHelp()
 	}
-
-	subcommand := os.Args[1]
-	flagVersion = subcommand == "version"
-	if subcommand == "token" {
-		flagToken = true
-		parseTokenFlags()
-	}
 }
 
 func main() {
-	if flagVersion {
-		fmt.Println(version)
-		os.Exit(0)
+	flags, err := ParseFlags(os.Args)
+	if err != nil {
+		exit(err.Error(), 1)
 	}
 
-	if flagToken {
-		token, err := createToken()
+	if flags.Version {
+		exit(version, 0)
+	}
+
+	config, err := NewConfigFromFlags(flags)
+	if err != nil {
+		exit(err.Error(), 1)
+	}
+
+	if flags.Token {
+		token, err := config.CreateToken()
 		if err != nil {
-			fmt.Println("appledev:", err)
-			os.Exit(1)
+			exit(err.Error(), 1)
 		}
 
-		fmt.Println(token)
+		exit(token, 0)
+	}
+
+	if flags.GenerateConfig {
+		err = config.WriteToFile(flags.OutputFile)
+		if err != nil {
+			exit(err.Error(), 1)
+		}
+
 		os.Exit(0)
 	}
+
+	exitHelp()
 }
 
-func exitHelp() {
-	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
-	fmt.Println("  token    \tCreate an apple developer token.")
-	fmt.Println("  version    \tPrint the version of this application.")
-	os.Exit(1)
-}
-
-func parseTokenFlags() {
-	tokenCmd := flag.NewFlagSet("token", flag.ExitOnError)
-	tokenCmd.StringVar(&flagTokenPKFile, "pk", flagTokenPKFile, "(required) The path to a file containing your PEM encoded private key.")
-	tokenCmd.StringVar(&flagTokenKeyID, "kid", flagTokenKeyID, "(required) The Key ID associated with your private key.")
-	tokenCmd.StringVar(&flagTokenTeamID, "tid", flagTokenTeamID, "(required) The Team ID from your developer account.")
-	tokenCmd.StringVar(&flagTokenServiceID, "sid", flagTokenServiceID, "(required) The Service ID from your developer account.")
-	tokenCmd.DurationVar(&flagTokenDuration, "d", flagTokenDuration, "How long the token will be valid for.")
-	tokenCmd.Parse(os.Args[2:])
-
-	if len(flagTokenPKFile) < 1 {
-		fmt.Fprintf(os.Stderr, "%s token: Private key file path is required.\n\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "Usage of %s token:\n", os.Args[0])
-		tokenCmd.PrintDefaults()
-		os.Exit(1)
+func exit(content string, code int) {
+	if code == 1 {
+		fmt.Fprintln(os.Stderr, app+":", content)
+	} else {
+		fmt.Println(content)
 	}
-}
-
-func createToken() (string, error) {
-	tokenProvider := appledev.ApiTokenProvider{
-		KeyID:     flagTokenKeyID,
-		TeamID:    flagTokenTeamID,
-		ServiceID: flagTokenServiceID,
-		Duration:  flagTokenDuration,
-	}
-
-	bytes, err := os.ReadFile(flagTokenPKFile)
-	if err != nil {
-		return "", err
-	}
-
-	token, err := tokenProvider.SignedJWT(bytes)
-	if err != nil {
-		return "", err
-	}
-
-	return token, nil
+	os.Exit(code)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/shawntoffel/go-appledev
 
 go 1.18
 
-require github.com/golang-jwt/jwt/v4 v4.4.2
+require github.com/golang-jwt/jwt/v4 v4.4.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
-github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5AU=
+github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=


### PR DESCRIPTION
Added support for loading args from a config file.

```json
{
  "kid": "key ID",
  "tid": "team ID",
  "sid": "service ID",
  "d": "10m",
  "pk": "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----"
}
```

```sh
./appledev token -c appledev_config.json
```